### PR TITLE
:book: :white_check_mark: :tada: Separate credit card numbers from token generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,13 @@ try {
 
 ### Using Methods
 
-To use any of the methods below, call the listed method as a static on the `StripeTestToken` class
+To use any of the methods below, call the listed method as a static on the `StripeTestToken` class. If you only want to return the corresponding card number, such as with Selenium or Laravel Dusk, you can call the same method on the `StripeCardNumber` class.
 
 ```php
 <?php 
 
-\JacobBennett\StripeTestToken::methodNameHere();
+\JacobBennett\StripeCardNumber::validVisa(); // Returns the valid Visa card number 4012888888881881
+\JacobBennett\StripeTestToken::validVisa(); // Attempts to generate a token against the Stripe API for a valid Visa card
 ```
 
 ### Testing

--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ To use any of the methods below, call the listed method as a static on the `Stri
 \JacobBennett\StripeTestToken::methodNameHere();
 ```
 
+### Testing
+
+In order to run the full test suite, you must have `STRIPE_KEY` set in your environment, as the test will hit the Stripe API in order to generate a test token.
+
+```
+$ STRIPE_KEY=sk_test_YourTestKeyHere phpunit tests/
+```
+
 ### Test card numbers
 Genuine card information cannot be used in test mode. Instead, use any of the following test card methods to create a successful payment token:
 

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,9 @@
         "stripe/stripe-php": "^4.0",
         "php": ">=5.3"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^4.8"
+    },
     "autoload": {
         "psr-4": {
             "JacobBennett\\": "src"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false">
+    <testsuites>
+        <testsuite name="Application Test Suite">
+            <directory suffix="Test.php">./tests</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/StripeCardNumber.php
+++ b/src/StripeCardNumber.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace JacobBennett;
+
+use BadMethodCallException;
+
+/**
+ * Provide access to varying valid and exceptional card numbers
+ * independently of having to actually create a Stripe token.
+ */
+class StripeCardNumber
+{
+    const CARDS = [
+        // valid cards
+        'validVisa'              => 4012888888881881,
+        'validVisaDebit'         => 4012888888881881,
+        'validMastercard'        => 5555555555554444,
+        'validMastercardDebit'   => 5200828282828210,
+        'validMastercardPrepaid' => 5105105105105100,
+        'validAmex'              => 378282246310005,
+        'validDiscover'          => 6011111111111117,
+        'validDinersClub'        => 30569309025904,
+        'validJCB'               => 3530111333300000,
+
+        // exceptional responses
+        'successDirectToBalance' => 4000000000000077,
+        'addressZipFail'         => 4000000000000010,
+        'addressFail'            => 4000000000000028,
+        'zipFail'                => 4000000000000036,
+        'addressZipUnavailable'  => 4000000000000044,
+        'cvcFail'                => 4000000000000101,
+        'customerChargeFail'     => 4000000000000341,
+        'successWithReview'      => 4000000000009235,
+        'declineCard'            => 4000000000000002,
+        'declineFraudulentCard'  => 4100000000000019,
+        'declineIncorrectCvc'    => 4000000000000127,
+        'declineExpiredCard'     => 4000000000000069,
+        'declineProcessingError' => 4000000000000119,
+        'declineIncorrectNumber' => 4242424242424241,
+    ];
+
+    public static function __callStatic($method, $args)
+    {
+        if (! array_key_exists($method, static::CARDS)) {
+            throw new BadMethodCallException("The provided card type {$method} is not defined.");
+        }
+
+        return static::CARDS[$method];
+    }
+}

--- a/src/StripeTestToken.php
+++ b/src/StripeTestToken.php
@@ -2,8 +2,9 @@
 
 namespace JacobBennett;
 
-use Stripe\Token;
+use JacobBennett\StripeCardNumber;
 use Stripe\Stripe;
+use Stripe\Token;
 
 /**
  * Quickly create Stripe test tokens
@@ -12,36 +13,6 @@ use Stripe\Stripe;
  */
 class StripeTestToken
 {
-
-    const CARDS = [
-        // valid cards
-        'validVisa'              => 4012888888881881,
-        'validVisaDebit'         => 4000056655665556,
-        'validMastercard'        => 5555555555554444,
-        'validMastercardDebit'   => 5200828282828210,
-        'validMastercardPrepaid' => 5105105105105100,
-        'validAmex'              => 378282246310005,
-        'validDiscover'          => 6011111111111117,
-        'validDinersClub'        => 30569309025904,
-        'validJCB'               => 3530111333300000,
-
-        // exceptional responses
-        'successDirectToBalance' => 4000000000000077,
-        'addressZipFail'         => 4000000000000010,
-        'addressFail'            => 4000000000000028,
-        'zipFail'                => 4000000000000036,
-        'addressZipUnavailable'  => 4000000000000044,
-        'cvcFail'                => 4000000000000101,
-        'customerChargeFail'     => 4000000000000341,
-        'successWithReview'      => 4000000000009235,
-        'declineCard'            => 4000000000000002,
-        'declineFraudulentCard'  => 4100000000000019,
-        'declineIncorrectCvc'    => 4000000000000127,
-        'declineExpiredCard'     => 4000000000000069,
-        'declineProcessingError' => 4000000000000119,
-        'declineIncorrectNumber' => 4242424242424241,
-    ];
-
     public static function setApiKey($key)
     {
         Stripe::setApiKey($key);
@@ -66,13 +37,8 @@ class StripeTestToken
         ])->id;
     }
 
-    public static function getCardNumber($type)
+    public static function getCardNumber($cardType)
     {
-        if (!isset(self::CARDS[$cardType]))
-        {
-            throw new \BadMethodCallException("The provided method {$type} was not found.");
-        }
-
-        return self::CARDS[$cardType];
+        return StripeCardNumber::{$cardType}();
     }
 }

--- a/tests/StripeCardNumberTest.php
+++ b/tests/StripeCardNumberTest.php
@@ -1,0 +1,152 @@
+<?php
+
+use JacobBennett\StripeCardNumber;
+
+class StripeCardNumberTest extends PHPUnit_Framework_TestCase
+{
+    /** @test */
+    public function it_throws_an_exception_for_an_invalid_method()
+    {
+        $this->setExpectedException(\BadMethodCallException::class);
+
+        StripeCardNumber::someInvalidCardMethod();
+    }
+
+    /** @test */
+    public function it_returns_a_valid_visa_card_number()
+    {
+        $this->assertSame(4012888888881881, StripeCardNumber::validVisa());
+    }
+
+    /** @test */
+    public function it_returns_a_valid_visa_debit_number()
+    {
+        $this->assertSame(4012888888881881, StripeCardNumber::validVisaDebit());
+    }
+
+    /** @test */
+    public function it_returns_a_valid_mastercard_number()
+    {
+        $this->assertSame(5555555555554444, StripeCardNumber::validMastercard());
+    }
+
+    /** @test */
+    public function it_returns_a_valid_mastercard_debit_number()
+    {
+        $this->assertSame(5200828282828210, StripeCardNumber::validMastercardDebit());
+    }
+
+    /** @test */
+    public function it_returns_a_valid_mastercard_prepaid_number()
+    {
+        $this->assertSame(5105105105105100, StripeCardNumber::validMastercardPrepaid());
+    }
+
+    /** @test */
+    public function it_returns_a_valid_amex_number()
+    {
+        $this->assertSame(378282246310005, StripeCardNumber::validAmex());
+    }
+
+    /** @test */
+    public function it_returns_a_valid_discover_number()
+    {
+        $this->assertSame(6011111111111117, StripeCardNumber::validDiscover());
+    }
+
+    /** @test */
+    public function it_returns_a_valid_diners_club_number()
+    {
+        $this->assertSame(30569309025904, StripeCardNumber::validDinersClub());
+    }
+
+    /** @test */
+    public function it_returns_a_valid_jcb_number()
+    {
+        $this->assertSame(3530111333300000, StripeCardNumber::validJCB());
+    }
+
+    /** @test */
+    public function it_returns_a_success_direct_to_balance_number()
+    {
+       $this->assertSame(4000000000000077, StripeCardNumber::successDirectToBalance()); 
+    }
+
+    /** @test */
+    public function it_returns_an_address_zip_fail_number()
+    {
+        $this->assertSame(4000000000000010, StripeCardNumber::addressZipFail());
+    }
+
+    /** @test */
+    public function it_returns_an_address_fail_number()
+    {
+        $this->assertSame(4000000000000028, StripeCardNumber::addressFail());
+    }
+
+    /** @test */
+    public function it_returns_a_zip_fail_number()
+    {
+        $this->assertSame(4000000000000036, StripeCardNumber::zipFail());
+    }
+
+    /** @test */
+    public function it_returns_an_address_zip_unavailable_number()
+    {
+        $this->assertSame(4000000000000044, StripeCardNumber::addressZipUnavailable());
+    }
+
+    /** @test */
+    public function it_returns_a_cvc_fail_number()
+    {
+        $this->assertSame(4000000000000101, StripeCardNumber::cvcFail());
+    }
+
+    /** @test */
+    public function it_returns_a_customer_charge_fail_number()
+    {
+        $this->assertSame(4000000000000341, StripeCardNumber::customerChargeFail());
+    }
+
+    /** @test */
+    public function it_returns_a_success_with_review_number()
+    {
+        $this->assertSame(4000000000009235, StripeCardNumber::successWithReview());
+    }
+
+    /** @test */
+    public function it_returns_a_declined_card_number()
+    {
+        $this->assertSame(4000000000000002, StripeCardNumber::declineCard());
+    }
+
+    /** @test */
+    public function it_returns_a_declined_fraudulent_card_number()
+    {
+        $this->assertSame(4100000000000019, StripeCardNumber::declineFraudulentCard());
+    }
+
+    /** @test */
+    public function it_returns_a_declined_incorrect_cvc_number()
+    {
+        $this->assertSame(4000000000000127, StripeCardNumber::declineIncorrectCvc());
+    }
+
+    /** @test */
+    public function it_returns_a_declined_expired_card_number()
+    {
+        $this->assertSame(4000000000000069, StripeCardNumber::declineExpiredCard());
+    }
+
+    /** @test */
+    public function it_returns_a_declined_processing_error_number()
+    {
+        $this->assertSame(4000000000000119, StripeCardNumber::declineProcessingError());
+    }
+
+    /** @test */
+    public function it_returns_a_declined_incorrect_number()
+    {
+        $this->assertSame(4242424242424241, StripeCardNumber::declineIncorrectNumber());
+    }
+}

--- a/tests/StripeTestTokenTest.php
+++ b/tests/StripeTestTokenTest.php
@@ -21,10 +21,20 @@ class StripeTestTokenTest extends PHPUnit_Framework_TestCase
     /** @test */
     public function it_returns_a_token_id_for_a_valid_visa()
     {
-        $this->assertFalse(trim(getenv('STRIPE_KEY')) === '', 'You must set the STRIPE_KEY in phpunit.xml');
+        $this->assertFalse(trim(getenv('STRIPE_KEY')) === '', 'You must set the STRIPE_KEY in your environment');
 
         StripeTestToken::setApiKey(getenv('STRIPE_KEY'));
 
         $this->assertTrue(is_string(StripeTestToken::create('validVisa')));
+    }
+
+    /** @test */
+    public function it_returns_a_token_id_for_a_valid_mastercard_using_static_access()
+    {
+        $this->assertFalse(trim(getenv('STRIPE_KEY')) === '', 'You must set the STRIPE_KEY in your environment');
+
+        StripeTestToken::setApiKey(getenv('STRIPE_KEY'));
+
+        $this->assertTrue(is_string(StripeTestToken::validMastercard()));
     }
 }

--- a/tests/StripeTestTokenTest.php
+++ b/tests/StripeTestTokenTest.php
@@ -13,6 +13,14 @@ class StripeTestTokenTest extends PHPUnit_Framework_TestCase
     }
 
     /** @test */
+    public function it_throws_an_exception_when_creating_a_token_with_a_non_existent_card_type_via_static_access()
+    {
+        $this->setExpectedException(\BadMethodCallException::class);
+
+        StripeTestToken::someNonExistentCardType();
+    }
+
+    /** @test */
     public function it_returns_a_valid_visa_card_number()
     {
         $this->assertSame(4012888888881881, StripeTestToken::getCardNumber('validVisa'));

--- a/tests/StripeTestTokenTest.php
+++ b/tests/StripeTestTokenTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use JacobBennett\StripeTestToken;
+
+class StripeTestTokenTest extends PHPUnit_Framework_TestCase
+{
+    /** @test */
+    public function it_throws_an_exception_when_requesting_a_non_existent_card_type()
+    {
+        $this->setExpectedException(\BadMethodCallException::class);
+
+        StripeTestToken::getCardNumber('someNonExistentCardType');
+    }
+
+    /** @test */
+    public function it_returns_a_valid_visa_card_number()
+    {
+        $this->assertSame(4012888888881881, StripeTestToken::getCardNumber('validVisa'));
+    }
+
+    /** @test */
+    public function it_returns_a_token_id_for_a_valid_visa()
+    {
+        $this->assertFalse(trim(getenv('STRIPE_KEY')) === '', 'You must set the STRIPE_KEY in phpunit.xml');
+
+        StripeTestToken::setApiKey(getenv('STRIPE_KEY'));
+
+        $this->assertTrue(is_string(StripeTestToken::create('validVisa')));
+    }
+}


### PR DESCRIPTION
In order to close #3, separate the return of valid and exceptional card numbers into their own object, allowing users to fetch them via named methods independently of generating Stripe tokens.

This will allow users to generate tokens with which to fill forms in integration test scenarios (i.e. Selenium), or the upcoming Laravel Dusk.