### PR TITLE
Test Improvements

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
          backupStaticAttributes="false"
+         bootstrap="vendor/autoload.php"
          colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,7 +7,8 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false">
+         stopOnFailure="false"
+         verbose="true">
     <testsuites>
         <testsuite name="Application Test Suite">
             <directory suffix="Test.php">./tests</directory>

--- a/tests/StripeTestTokenTest.php
+++ b/tests/StripeTestTokenTest.php
@@ -29,7 +29,9 @@ class StripeTestTokenTest extends PHPUnit_Framework_TestCase
     /** @test */
     public function it_returns_a_token_id_for_a_valid_visa()
     {
-        $this->assertFalse(trim(getenv('STRIPE_KEY')) === '', 'You must set the STRIPE_KEY in your environment');
+        if(! getenv('STRIPE_KEY')) {
+            $this->markTestSkipped('You must set the STRIPE_KEY in your environment');
+        }
 
         StripeTestToken::setApiKey(getenv('STRIPE_KEY'));
 
@@ -39,7 +41,9 @@ class StripeTestTokenTest extends PHPUnit_Framework_TestCase
     /** @test */
     public function it_returns_a_token_id_for_a_valid_mastercard_using_static_access()
     {
-        $this->assertFalse(trim(getenv('STRIPE_KEY')) === '', 'You must set the STRIPE_KEY in your environment');
+        if(! getenv('STRIPE_KEY')) {
+            $this->markTestSkipped('You must set the STRIPE_KEY in your environment');
+        }
 
         StripeTestToken::setApiKey(getenv('STRIPE_KEY'));
 


### PR DESCRIPTION
Ensure that composer autoloader is bootstrapped in phpunit.xml for all tests.

Skip tests if there is a missing STRIPE_KEY rather than failing them.