### PR TITLE
Add test cards for SCA regulations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: php
 
 php:
-  - 5.6
-  - 7.0
-  - 7.1
+  - 7.2
+  - 7.3
 
 env:
   matrix:

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
     ],
     "require": {
         "stripe/stripe-php": "^4.0|^5.0|^6.0",
-        "php": ">=5.3"
+        "php": ">=7.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8"
+        "phpunit/phpunit": "^8.0"
     },
     "scripts": {
         "test": "phpunit"

--- a/src/StripeCardNumber.php
+++ b/src/StripeCardNumber.php
@@ -37,6 +37,11 @@ class StripeCardNumber
         'declineExpiredCard'     => 4000000000000069,
         'declineProcessingError' => 4000000000000119,
         'declineIncorrectNumber' => 4242424242424241,
+
+        // SCA
+        'scaAuthOneTimePayments' => 4000002500003155,
+        'scaAuthRequired' => 4000002760003184,
+        'scaAuthOnSession' => 4000003800000446,
     ];
 
     public static function __callStatic($method, $args)

--- a/tests/StripeCardNumberTest.php
+++ b/tests/StripeCardNumberTest.php
@@ -1,13 +1,15 @@
 <?php
 
 use JacobBennett\StripeCardNumber;
+use PHPUnit\Framework\TestCase;
 
-class StripeCardNumberTest extends PHPUnit_Framework_TestCase
+
+class StripeCardNumberTest extends TestCase
 {
     /** @test */
     public function it_throws_an_exception_for_an_invalid_method()
     {
-        $this->setExpectedException(\BadMethodCallException::class);
+        $this->expectException(\BadMethodCallException::class);
 
         StripeCardNumber::someInvalidCardMethod();
     }

--- a/tests/StripeCardNumberTest.php
+++ b/tests/StripeCardNumberTest.php
@@ -151,4 +151,22 @@ class StripeCardNumberTest extends TestCase
     {
         $this->assertSame(4242424242424241, StripeCardNumber::declineIncorrectNumber());
     }
+
+    /** @test */
+    public function it_returns_a_sca_one_time_payment_number()
+    {
+        $this->assertSame(4000002500003155, StripeCardNumber::scaAuthOneTimePayments());
+    }
+
+    /** @test */
+    public function it_returns_a_sca_auth_required_number()
+    {
+        $this->assertSame(4000002760003184, StripeCardNumber::scaAuthRequired());
+    }
+
+    /** @test */
+    public function it_returns_a_sca_auth_on_session_required_number()
+    {
+        $this->assertSame(4000003800000446, StripeCardNumber::scaAuthOnSession());
+    }
 }

--- a/tests/StripeTestTokenTest.php
+++ b/tests/StripeTestTokenTest.php
@@ -1,13 +1,14 @@
 <?php
 
 use JacobBennett\StripeTestToken;
+use PHPUnit\Framework\TestCase;
 
-class StripeTestTokenTest extends PHPUnit_Framework_TestCase
+class StripeTestTokenTest extends TestCase
 {
     /** @test */
     public function it_throws_an_exception_when_requesting_a_non_existent_card_type()
     {
-        $this->setExpectedException(\BadMethodCallException::class);
+        $this->expectException(\BadMethodCallException::class);
 
         StripeTestToken::getCardNumber('someNonExistentCardType');
     }
@@ -15,7 +16,7 @@ class StripeTestTokenTest extends PHPUnit_Framework_TestCase
     /** @test */
     public function it_throws_an_exception_when_creating_a_token_with_a_non_existent_card_type_via_static_access()
     {
-        $this->setExpectedException(\BadMethodCallException::class);
+        $this->expectException(\BadMethodCallException::class);
 
         StripeTestToken::someNonExistentCardType();
     }


### PR DESCRIPTION
I would like to add cards for the new SCA regulations: https://stripe.com/docs/testing#regulatory-cards

I have also upgraded PHPUnit as there were deprecation warnings and PHPUnit 4 has not been supported for a while: https://phpunit.de/supported-versions.html this has required me to bump the PHP version requirement to 7.2.

So this PR is a breaking change. I can redo the PR without the breaking change if you wish, but I feel the upgrade is useful.