### PR TITLE
Add support for latest Stripe SDK versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "stripe/stripe-php": "^4.0|^5.0|^6.0|^7.0",
+        "stripe/stripe-php": "^4.0|^5.0|^6.0|^7.0|^8.0|^9.0",
         "php": ">=7.2|^8.0"
     },
     "require-dev": {

--- a/src/StripeCardNumber.php
+++ b/src/StripeCardNumber.php
@@ -7,6 +7,35 @@ use BadMethodCallException;
 /**
  * Provide access to varying valid and exceptional card numbers
  * independently of having to actually create a Stripe token.
+ * 
+ * @method static int validVisa()
+ * @method static int validVisaDebit()
+ * @method static int validMastercard()
+ * @method static int validMastercardDebit()
+ * @method static int validMastercardPrepaid()
+ * @method static int validAmex()
+ * @method static int validDiscover()
+ * @method static int validDinersClub()
+ * @method static int validJCB()
+ * @method static int successDirectToBalance()
+ * @method static int addressZipFail()
+ * @method static int addressFail()
+ * @method static int zipFail()
+ * @method static int addressZipUnavailable()
+ * @method static int cvcFail()
+ * @method static int customerChargeFail()
+ * @method static int successWithReview()
+ * @method static int declineCard()
+ * @method static int declineFraudulentCard()
+ * @method static int declineIncorrectCvc()
+ * @method static int declineExpiredCard()
+ * @method static int declineProcessingError()
+ * @method static int declineIncorrectNumber()
+ * @method static int scaAuthOneTimePayments()
+ * @method static int scaAuthRequired()
+ * @method static int scaAuthOnSession()
+ * 
+ * @see https://stripe.com/docs/testing#cards
  */
 class StripeCardNumber
 {
@@ -40,8 +69,8 @@ class StripeCardNumber
 
         // SCA
         'scaAuthOneTimePayments' => 4000002500003155,
-        'scaAuthRequired' => 4000002760003184,
-        'scaAuthOnSession' => 4000003800000446,
+        'scaAuthRequired'        => 4000002760003184,
+        'scaAuthOnSession'       => 4000003800000446,
     ];
 
     public static function __callStatic($method, $args)

--- a/src/StripeTestToken.php
+++ b/src/StripeTestToken.php
@@ -8,8 +8,35 @@ use Stripe\Token;
 
 /**
  * Quickly create Stripe test tokens
+ * 
+ * @method static \Stripe\Token validVisa()
+ * @method static \Stripe\Token validVisaDebit()
+ * @method static \Stripe\Token validMastercard()
+ * @method static \Stripe\Token validMastercardDebit()
+ * @method static \Stripe\Token validMastercardPrepaid()
+ * @method static \Stripe\Token validAmex()
+ * @method static \Stripe\Token validDiscover()
+ * @method static \Stripe\Token validDinersClub()
+ * @method static \Stripe\Token validJCB()
+ * @method static \Stripe\Token successDirectToBalance()
+ * @method static \Stripe\Token addressZipFail()
+ * @method static \Stripe\Token addressFail()
+ * @method static \Stripe\Token zipFail()
+ * @method static \Stripe\Token addressZipUnavailable()
+ * @method static \Stripe\Token cvcFail()
+ * @method static \Stripe\Token customerChargeFail()
+ * @method static \Stripe\Token successWithReview()
+ * @method static \Stripe\Token declineCard()
+ * @method static \Stripe\Token declineFraudulentCard()
+ * @method static \Stripe\Token declineIncorrectCvc()
+ * @method static \Stripe\Token declineExpiredCard()
+ * @method static \Stripe\Token declineProcessingError()
+ * @method static \Stripe\Token declineIncorrectNumber()
+ * @method static \Stripe\Token scaAuthOneTimePayments()
+ * @method static \Stripe\Token scaAuthRequired()
+ * @method static \Stripe\Token scaAuthOnSession()
  *
- * reference https://stripe.com/docs/testing#cards
+ * @see https://stripe.com/docs/testing#cards
  */
 class StripeTestToken
 {


### PR DESCRIPTION
This just adds support for `8.0` and `9.0`. It also adds some `@method` annotations so that the static methods can autocomplete in IDEs that support it.